### PR TITLE
EP-94417 : Header customisation for LMS and CMS instance

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -255,9 +255,11 @@
               <h3 class="title"><span class="label"><a href="${get_online_help_info(online_help_token)['doc_url']}" title="${_('Contextual Online Help')}" rel="noopener" target="_blank">${_("Help")}</a></span></h3>
             </li>
           % endif
+          <!--
           <li class="nav-item nav-account-user">
             <%include file="user_dropdown.html" args="online_help_token=online_help_token" />
           </li>
+          -->
         </ol>
       </nav>
 

--- a/lms/templates/header/header.html
+++ b/lms/templates/header/header.html
@@ -67,17 +67,6 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
     <div class="mobile-menu hidden" aria-label=${_("More Options")} role="menu" id="mobile-menu"></div>
 </header>
 
-% if course:
-<!--[if lte IE 9]>
-<div class="ie-banner" aria-hidden="true">${Text(_('{begin_strong}Warning:{end_strong} Your browser is not fully supported. We strongly recommend using {chrome_link} or {ff_link}.')).format(
-    begin_strong=HTML('<strong>'),
-    end_strong=HTML('</strong>'),
-    chrome_link=HTML('<a href="https://www.google.com/chrome" rel="noopener" target="_blank">Chrome</a>'),
-    ff_link=HTML('<a href="http://www.mozilla.org/firefox" rel="noopener" target="_blank">Firefox</a>'),
-)}</div>
-<![endif]-->
-% endif
-
 % if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
   <%include file="../widgets/cookie-consent.html" />
 % endif

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -200,7 +200,9 @@ from common.djangoapps.pipeline_mako import render_require_js_path_overrides
     <a class="nav-skip sr-only sr-only-focusable" href="#main">${_("Skip to main content")}</a>
 
     % if not disable_header:
+        <!--
         <%include file="${static.get_template_path('header.html')}" args="online_help_token=online_help_token" />
+        -->
         <%include file="/preview_menu.html" />
     % endif
 


### PR DESCRIPTION
Header customisation

For LMS instance remove the code from header.html file and comment out the header from main.html file
For CMS instance comment out user_dropdown code from the header.html file 

For both the instance we have to setup the ENABLE_HELP_LINK = False which disable the Help button from the header file