### PR TITLE
EP-94484 : Disable the WIKI home page button from course wiki page

### DIFF
--- a/lms/templates/wiki/includes/breadcrumbs.html
+++ b/lms/templates/wiki/includes/breadcrumbs.html
@@ -14,7 +14,9 @@
       create_article_root = None
     %>
     %for ancestor in urlpath.cached_ancestors:
+    %if not loop.first:
       <li><a href="${reverse('wiki:get', kwargs={'path' : ancestor.path})}">${ancestor.article.current_revision.title}</a></li>
+    %endif
       <%
         if not create_article_root and ancestor.article.can_write(user):
           create_article_root = ancestor


### PR DESCRIPTION
Disable the WIKI home page button from course wiki page.

I adjusted the wiki page so that the first navigation button no longer goes to the wiki homepage.
For that I added the coditional statement in the code so that it escaped first navigation.