### PR TITLE
EP-94486 : Remove the course team option and Invite option

### DIFF
--- a/cms/templates/certificates.html
+++ b/cms/templates/certificates.html
@@ -115,7 +115,9 @@ CMS.User.isGlobalStaff = '${is_global_staff | n, js_escaped_string}'=='True' ? t
             <ul>
               <li class="nav-item"><a href="${details_url}">${_("Details & Schedule")}</a></li>
               <li class="nav-item"><a href="${grading_url}">${_("Grading")}</a></li>
+              <!--
               <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
+              -->
               <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
               <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
               % if mfe_proctored_exam_settings_url:

--- a/cms/templates/group_configurations.html
+++ b/cms/templates/group_configurations.html
@@ -126,7 +126,9 @@ from six.moves.urllib.parse import quote
           <ul>
             <li class="nav-item"><a href="${details_url}">${_("Details & Schedule")}</a></li>
             <li class="nav-item"><a href="${grading_url}">${_("Grading")}</a></li>
+            <!--
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
+            -->
             <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>
             % if mfe_proctored_exam_settings_url:
               <li class="nav-item"><a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a></li>

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -88,7 +88,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                 class="long" id="course-name" readonly />
             </li>
           </ol>
-
+          <!--
           % if not marketing_enabled:
           <div class="note note-promotion note-promotion-courseURL has-actions">
             <h3 class="title">${_("Course Summary Page")} <span class="tip">${_("(for student enrollment and access)")}</span></h3>
@@ -118,7 +118,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
             </ul>
           </div>
           % endif
-
+          -->
           % if marketing_enabled:
           <div class="notice notice-incontext notice-workflow">
             <h3 class="title">${_("Promoting Your Course with {platform_name}").format(platform_name=settings.PLATFORM_NAME)}</h3>

--- a/cms/templates/settings_advanced.html
+++ b/cms/templates/settings_advanced.html
@@ -146,7 +146,9 @@
           <ul>
             <li class="nav-item"><a href="${details_url}">${_("Details & Schedule")}</a></li>
             <li class="nav-item"><a href="${grading_url}">${_("Grading")}</a></li>
+            <!--
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
+            -->
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
             % if mfe_proctored_exam_settings_url:
               <li class="nav-item"><a href="${mfe_proctored_exam_settings_url}">${_("Proctored Exam Settings")}</a></li>

--- a/cms/templates/settings_graders.html
+++ b/cms/templates/settings_graders.html
@@ -164,7 +164,9 @@
         <nav class="nav-related" aria-label="${_('Other Course Settings')}">
           <ul>
             <li class="nav-item"><a href="${detailed_settings_url}">${_("Details & Schedule")}</a></li>
+            <!--
             <li class="nav-item"><a href="${course_team_url}">${_("Course Team")}</a></li>
+            -->
             <li class="nav-item"><a href="${utils.reverse_course_url('group_configurations_list_handler', context_course.id)}">${_("Group Configurations")}</a></li>
             % if has_studio_advanced_settings_access(request.user):
             <li class="nav-item"><a href="${advanced_settings_url}">${_("Advanced Settings")}</a></li>

--- a/cms/templates/ux/reference/fragments/course-settings.html
+++ b/cms/templates/ux/reference/fragments/course-settings.html
@@ -36,7 +36,7 @@
               <input title="This field is disabled: this information cannot be changed." type="text" class="long" id="course-name" readonly="">
             </li>
           </ol>
-
+          <!--
           <div class="note note-promotion note-promotion-courseURL has-actions">
             <h3 class="title">Course Summary Page <span class="tip">(for student enrollment and access)</span></h3>
             <div class="copy">
@@ -52,7 +52,7 @@
               </li>
             </ul>
           </div>
-
+          -->
         </div>
         <hr class="divide">
 


### PR DESCRIPTION
Remove the course team option and Invite option

I worked on the Schedule and Detail pages. I comment out the code to remove the course team from the left navigation bar and also removed the course summary page along with the option to invite new members.